### PR TITLE
feat: add carousel flip effect for instructors

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -301,17 +301,50 @@ button:hover::after,
 }
 
 /* ========== EĞİTMENLER ========== */
-.instructor-grid {
+.instructor-carousel {
+  position: relative;
+}
+
+.instructor-track {
   display: flex;
   gap: 2rem;
-  flex-wrap: wrap;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 1rem;
+}
+
+.instructor-track::-webkit-scrollbar {
+  display: none;
 }
 
 /* Eğitmen kartları - flip efekti */
 .instructor-card {
-  flex: 1 1 22%;
+  flex: 0 0 250px;
+  scroll-snap-align: start;
   perspective: 1000px;
   height: 320px;
+}
+
+.carousel-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.5);
+  border: none;
+  color: var(--color-text1);
+  font-size: 2rem;
+  padding: 0.5rem;
+  cursor: pointer;
+  z-index: 10;
+}
+
+.carousel-btn.prev {
+  left: -1rem;
+}
+
+.carousel-btn.next {
+  right: -1rem;
 }
 
 .instructor-card .card-inner {
@@ -491,14 +524,17 @@ button:hover::after,
     flex: 1 1 100%;
   }
 
-  .instructor-grid {
-    flex-direction: column;
-    align-items: center;
+  .instructor-track {
+    gap: 1rem;
   }
 
   .instructor-card {
-    flex: 1 1 100%;
+    flex: 0 0 80%;
     max-width: 300px;
+  }
+
+  .carousel-btn {
+    display: none;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -86,60 +86,64 @@
   <!-- Instructors Section -->
   <section id="instructors" class="instructors section container">
     <h2>Eğitmenlerimiz</h2>
-    <div class="instructor-grid">
-      <!-- Eğitmen kartları flip efekti için ön ve arka yüzlere ayrıldı -->
-      <div class="instructor-card">
-        <div class="card-inner">
-          <div class="card-front">
-            <img src="images/instructors/emre.jpg" alt="Emre - Hip-Hop" />
-            <h4>Emre</h4>
-            <p>Hip-Hop</p>
+    <div class="instructor-carousel">
+      <button class="carousel-btn prev"><i class="fas fa-chevron-left"></i></button>
+      <div class="instructor-track">
+        <!-- Eğitmen kartları flip efekti için ön ve arka yüzlere ayrıldı -->
+        <div class="instructor-card">
+          <div class="card-inner">
+            <div class="card-front">
+              <img src="images/instructors/emre.jpg" alt="Emre - Hip-Hop" />
+              <h4>Emre</h4>
+              <p>Hip-Hop</p>
+            </div>
+            <div class="card-back">
+              <h4>Emre</h4>
+              <p>Hip-Hop eğitmeni, 5+ yıl deneyim.</p>
+            </div>
           </div>
-          <div class="card-back">
-            <h4>Emre</h4>
-            <p>Hip-Hop eğitmeni, 5+ yıl deneyim.</p>
+        </div>
+        <div class="instructor-card">
+          <div class="card-inner">
+            <div class="card-front">
+              <img src="images/instructors/elif.jpg" alt="Elif - Salsa" />
+              <h4>Elif</h4>
+              <p>Salsa</p>
+            </div>
+            <div class="card-back">
+              <h4>Elif</h4>
+              <p>Salsa ustası, ritme ayak uydur.</p>
+            </div>
+          </div>
+        </div>
+        <div class="instructor-card">
+          <div class="card-inner">
+            <div class="card-front">
+              <img src="images/instructors/merve.jpg" alt="Merve - Modern" />
+              <h4>Merve</h4>
+              <p>Modern Dans</p>
+            </div>
+            <div class="card-back">
+              <h4>Merve</h4>
+              <p>Modern dans ile duygunu ifade et.</p>
+            </div>
+          </div>
+        </div>
+        <div class="instructor-card">
+          <div class="card-inner">
+            <div class="card-front">
+              <img src="images/instructors/kerem.jpg" alt="Kerem - Hip-Hop" />
+              <h4>Kerem</h4>
+              <p>Hip-Hop</p>
+            </div>
+            <div class="card-back">
+              <h4>Kerem</h4>
+              <p>Sahne enerjisi yüksek hip-hop eğitmeni.</p>
+            </div>
           </div>
         </div>
       </div>
-      <div class="instructor-card">
-        <div class="card-inner">
-          <div class="card-front">
-            <img src="images/instructors/elif.jpg" alt="Elif - Salsa" />
-            <h4>Elif</h4>
-            <p>Salsa</p>
-          </div>
-          <div class="card-back">
-            <h4>Elif</h4>
-            <p>Salsa ustası, ritme ayak uydur.</p>
-          </div>
-        </div>
-      </div>
-      <div class="instructor-card">
-        <div class="card-inner">
-          <div class="card-front">
-            <img src="images/instructors/merve.jpg" alt="Merve - Modern" />
-            <h4>Merve</h4>
-            <p>Modern Dans</p>
-          </div>
-          <div class="card-back">
-            <h4>Merve</h4>
-            <p>Modern dans ile duygunu ifade et.</p>
-          </div>
-        </div>
-      </div>
-      <div class="instructor-card">
-        <div class="card-inner">
-          <div class="card-front">
-            <img src="images/instructors/kerem.jpg" alt="Kerem - Hip-Hop" />
-            <h4>Kerem</h4>
-            <p>Hip-Hop</p>
-          </div>
-          <div class="card-back">
-            <h4>Kerem</h4>
-            <p>Sahne enerjisi yüksek hip-hop eğitmeni.</p>
-          </div>
-        </div>
-      </div>
+      <button class="carousel-btn next"><i class="fas fa-chevron-right"></i></button>
     </div>
   </section>
 

--- a/js/script.js
+++ b/js/script.js
@@ -36,6 +36,29 @@ document.querySelectorAll('.instructor-card').forEach(card => {
   });
 });
 
+// Eğitmen slider'ı ok butonları
+const instructorTrack = document.querySelector('.instructor-track');
+const prevBtn = document.querySelector('.carousel-btn.prev');
+const nextBtn = document.querySelector('.carousel-btn.next');
+
+if (instructorTrack && prevBtn && nextBtn) {
+  const getScrollAmount = () => {
+    const card = instructorTrack.querySelector('.instructor-card');
+    if (!card) return 0;
+    const style = getComputedStyle(instructorTrack);
+    const gap = parseInt(style.columnGap || style.gap) || 0;
+    return card.getBoundingClientRect().width + gap;
+  };
+
+  prevBtn.addEventListener('click', () => {
+    instructorTrack.scrollBy({ left: -getScrollAmount(), behavior: 'smooth' });
+  });
+
+  nextBtn.addEventListener('click', () => {
+    instructorTrack.scrollBy({ left: getScrollAmount(), behavior: 'smooth' });
+  });
+}
+
 // Hamburger menü
 const hamburger = document.querySelector('.hamburger');
 const navLinks = document.querySelector('.nav-links');


### PR DESCRIPTION
## Summary
- replace static instructor grid with horizontal carousel
- add flip effect and touch-friendly arrows for instructor cards
- style carousel for mobile swipe and desktop navigation

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895b9e7c2fc832cadff59b37fdd5bbd